### PR TITLE
adiciona cenarios de teste para o trial do moip

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ plan = {
     length: 1,
     unit: "MONTH"
   },
-  billing_cycles: 12
+  billing_cycles: 12,
+  trial: {
+    enabled: true,
+    days: 10
+  }
 }
 
 request = Moip::Assinaturas::Plan.create(plan)

--- a/spec/fixtures/create_plan.json
+++ b/spec/fixtures/create_plan.json
@@ -8,5 +8,9 @@
     "interval": {
         "length": 1,
         "unit": "MONTH"
-        }
+    },
+    "trial": {
+        "enabled": true,
+        "days": 10
+    }
 }

--- a/spec/fixtures/details_plan.json
+++ b/spec/fixtures/details_plan.json
@@ -10,5 +10,9 @@
         "length": 1,
         "unit": "MONTH"
     },
-    "billing_cycles": 1
+    "billing_cycles": 1,
+    "trial": {
+        "enabled": true,
+        "days": 10
+    }
 }

--- a/spec/fixtures/details_subscription.json
+++ b/spec/fixtures/details_subscription.json
@@ -28,5 +28,17 @@
         "code": "cliente1",
         "fullname": "Nome e Sobrenome",
         "email": "assinaturas@moip.com.br"
+    },
+    "trial": {
+        "start": {
+            "month": 9,
+            "year": 2013,
+            "day": 27
+        },
+        "end": {
+            "month": 10,
+            "year": 2013,
+            "day": 17
+        }
     }
 }

--- a/spec/moip-assinaturas/plan_spec.rb
+++ b/spec/moip-assinaturas/plan_spec.rb
@@ -15,7 +15,11 @@ describe Moip::Assinaturas::Plan do
         length: 1,
         unit: "MONTH"
       },
-      billing_cycles: 12
+      billing_cycles: 12,
+      trial: {
+        enabled: true,
+        days: 10
+      }
     }
 
     FakeWeb.register_uri(
@@ -56,6 +60,14 @@ describe Moip::Assinaturas::Plan do
     request = Moip::Assinaturas::Plan.details('plano01')
     request[:success].should      be_true
     request[:plan][:code].should  == 'plano01'
+  end
+
+  context "Trial" do
+    it "should get details from a plan with trial" do
+      request = Moip::Assinaturas::Plan.details('plano01')
+      expect(request[:plan][:trial][:days]).to eq 10
+      expect(request[:plan][:trial][:enabled]).to be_true
+    end
   end
 
 end

--- a/spec/moip-assinaturas/subscription_spec.rb
+++ b/spec/moip-assinaturas/subscription_spec.rb
@@ -1,6 +1,13 @@
 # coding: utf-8
 require 'spec_helper'
 
+RSpec::Matchers.define :have_valid_trial_dates do
+  match do |actual|
+    (actual[:start][:day] == 27 && actual[:start][:month] == 9 && actual[:start][:year] == 2013) && 
+    (actual[:end][:day] == 17 && actual[:end][:month] == 10 && actual[:end][:year] == 2013)
+  end
+end
+
 describe Moip::Assinaturas::Subscription do
   
   before(:all) do
@@ -79,5 +86,11 @@ describe Moip::Assinaturas::Subscription do
     request[:success].should be_true
   end
 
+  context "Trial" do
+    it "should get the subscription details with trial" do
+      request = Moip::Assinaturas::Subscription.details('assinatura1')
+      expect(request[:subscription][:trial]).to have_valid_trial_dates
+    end
+  end
 
 end


### PR DESCRIPTION
O moip adicionou uma nova feature de trial.

Apenas adicionei mais cenários de testes para garantir o funcionamento do Trial na gem. Dado que vocês já utilizavam um hash acreditoque não foi necessário alterar mais nada no código de vocês.
